### PR TITLE
Updating documentation and example about Binary lambda invoke

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,12 +45,17 @@ Now that you have a lambda client, you can publish requests.
         'message':"hello"
     })
 
+    client_context = json.dumps({
+                    "custom": "custom text"
+    })
+
     # Invoke the lambda function
     response = client.invoke(
+        ClientContext=base64.b64encode(bytes(client_context, "utf-8")),
         FunctionName='arn:<partition>:lambda:<region>:<account id>:function:<function name>',
         InvocationType='RequestResponse',
-        Payload=payload,
-        Qualifier='2'
+        Payload=msg,
+        Qualifier='<targetFunctionQualifier>'
     )
 
 ==============

--- a/examples/BinaryLambdaInvoke/invokee.py
+++ b/examples/BinaryLambdaInvoke/invokee.py
@@ -1,6 +1,11 @@
 #
 # Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
+
+# Remember to mark your 'invokee' lambda as a binary
+# lambda. You can configure this on the lambda configuration page in the
+# console. 
+
 import logging
 import sys
 

--- a/examples/BinaryLambdaInvoke/invoker.py
+++ b/examples/BinaryLambdaInvoke/invoker.py
@@ -29,11 +29,11 @@ def handler(event, context):
 
     try:
         response = client.invoke(
-            ClientContext=base64.b64encode(bytes(client_context)),
-            FunctionName="arn:aws:lambda:<region>:<accountId>:function:<targetFunctionName>:<targetFunctionQualifier>",
+            ClientContext=base64.b64encode(bytes(client_context, "utf-8")),
+            FunctionName="arn:aws:lambda:<region>:<accountId>:function:<targetFunctionName>",
             InvocationType="RequestResponse",
             Payload="Non-JSON Data",
-            Qualifier="1",
+            Qualifier="<targetFunctionQualifier>",
         )
 
         logger.info(response["Payload"].read())


### PR DESCRIPTION
*Description of changes:*
The example and documentation in README.rst were not aligned and misleading. Also, invoker.py needs to have the client_context encoded using utf-8. This change is about making the README.rst and code aligned and clearer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
